### PR TITLE
modified simple typo in train_mlp.py

### DIFF
--- a/codes/3-neural_networks/multi-layer-perceptron/code/train_mlp.py
+++ b/codes/3-neural_networks/multi-layer-perceptron/code/train_mlp.py
@@ -221,7 +221,7 @@ with graph.as_default():
         test_summary_writer = tf.summary.FileWriter(test_summary_dir)
         test_summary_writer.add_graph(sess.graph)
 
-        # If fie-tuning flag in 'True' the model will be restored.
+        # If fine-tuning flag in 'True' the model will be restored.
         if FLAGS.fine_tuning:
             saver.restore(sess, os.path.join(FLAGS.checkpoint_root, checkpoint_prefix))
             print("Model restored for fine-tuning...")


### PR DESCRIPTION
In 224, I think 'fie-tuning ' is just simple typo, so I modified 'fie-tuning' to 'fine-tuning'