### PR TITLE
docs: fix simple typo, visualiaing -> visualising

### DIFF
--- a/docs/tutorials/1-basics/basic_math_operations/README.rst
+++ b/docs/tutorials/1-basics/basic_math_operations/README.rst
@@ -101,7 +101,7 @@ The results for running in the terminal is as bellow:
 
 
 
-If we run the Tensorboard using ``tensorboard --logdir="absolute/path/to/log_dir"`` we get the following when visualiaing the ``Graph``:
+If we run the Tensorboard using ``tensorboard --logdir="absolute/path/to/log_dir"`` we get the following when visualising the ``Graph``:
 
 .. figure:: https://github.com/astorfi/TensorFlow-World/blob/master/docs/_img/1-basics/basic_math_operations/graph-run.png
    :scale: 30 %


### PR DESCRIPTION
There is a small typo in docs/tutorials/1-basics/basic_math_operations/README.rst.

Should read `visualising` rather than `visualiaing`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md